### PR TITLE
Need to call super.initalize() in handlers when overriding initialize method.

### DIFF
--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/ZoneHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/ZoneHandler.java
@@ -90,6 +90,7 @@ public class ZoneHandler extends AbstractOmnilinkHandler {
     public void initialize() {
         updateZoneStatus();
         updateChannels();
+        super.initialize();
     }
 
     @Override


### PR DESCRIPTION
@digitaldan - 
  If you don't call super.initalize() channels are never linked because the handler stays stuck in the 'initalizing' state.

  