### PR TITLE
Remove thermostat caching

### DIFF
--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/AbstractOmnilinkHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/AbstractOmnilinkHandler.java
@@ -61,9 +61,11 @@ public abstract class AbstractOmnilinkHandler<T extends Status> extends BaseThin
      * @param t Status to process.
      */
     public void handleStatus(T t) {
-        this.status = Optional.ofNullable(t);
-        if (status.isPresent()) {
-            updateChannels(status.get());
+        if (t != null) {
+            this.status = Optional.of(t);
+            updateChannels(t);
+        } else {
+            logger.warn("Received null status update");
         }
     }
 

--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/AbstractOmnilinkHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/AbstractOmnilinkHandler.java
@@ -1,24 +1,86 @@
 package org.openhab.binding.omnilink.handler;
 
+import java.util.Optional;
+
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.openhab.binding.omnilink.OmnilinkBindingConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitaldan.jomnilinkII.MessageTypes.statuses.Status;
 
 /**
  *
  * @author Craig Hamilton
  *
  */
-public abstract class AbstractOmnilinkHandler extends BaseThingHandler {
+public abstract class AbstractOmnilinkHandler<T extends Status> extends BaseThingHandler {
+
+    private static Logger logger = LoggerFactory.getLogger(AbstractOmnilinkHandler.class);
 
     public AbstractOmnilinkHandler(Thing thing) {
         super(thing);
     }
 
+    private volatile Optional<T> status;
+
     public OmnilinkBridgeHandler getOmnilinkBridgeHander() {
         return (OmnilinkBridgeHandler) getBridge().getHandler();
+    }
+
+    @Override
+    public void initialize() {
+        Optional<T> status = retrieveStatus();
+        handleStatus(status.orElse(null)); // handle status will process null.
+        super.initialize();
+    }
+
+    /**
+     * Attempt to retrieve an updated status for this handler type.
+     *
+     * @return Optional with updated status if possible, empty optional otherwise.
+     */
+    protected abstract Optional<T> retrieveStatus();
+
+    /**
+     * Update channels associated with handler
+     *
+     * @param t Status object to update channels with
+     */
+    protected abstract void updateChannels(T t);
+
+    /**
+     * Process a status update for this handler. This will dispatch updateChannels where appropriate.
+     *
+     * @param t Status to process.
+     */
+    public void handleStatus(T t) {
+        this.status = Optional.ofNullable(t);
+        if (status.isPresent()) {
+            updateChannels(status.get());
+        }
+    }
+
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        logger.debug("channel linked: {} for zone {}", channelUID, getThingNumber());
+        if (status.isPresent()) {
+            updateChannels(status.get());
+        }
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        super.bridgeStatusChanged(bridgeStatusInfo);
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            initialize();
+        }
     }
 
     /**

--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/AudioZoneHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/AudioZoneHandler.java
@@ -1,5 +1,7 @@
 package org.openhab.binding.omnilink.handler;
 
+import java.util.Optional;
+
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -22,7 +24,7 @@ import com.digitaldan.jomnilinkII.MessageTypes.statuses.AudioZoneStatus;
  * @author Craig Hamilton
  *
  */
-public class AudioZoneHandler extends AbstractOmnilinkHandler implements ThingHandler {
+public class AudioZoneHandler extends AbstractOmnilinkHandler<AudioZoneStatus> implements ThingHandler {
 
     private Logger logger = LoggerFactory.getLogger(AudioZoneHandler.class);
 
@@ -102,7 +104,8 @@ public class AudioZoneHandler extends AbstractOmnilinkHandler implements ThingHa
                 audioZoneID);
     }
 
-    public void handleAudioZoneStatus(AudioZoneStatus status) {
+    @Override
+    public void updateChannels(AudioZoneStatus status) {
         logger.debug("Audio Zone Status {}", status);
         handlePowerState(status);
         handleMuteStatus(status);
@@ -122,17 +125,16 @@ public class AudioZoneHandler extends AbstractOmnilinkHandler implements ThingHa
     }
 
     @Override
-    public void channelLinked(ChannelUID channelUID) {
-        logger.debug("channel linked: {}", channelUID);
+    protected Optional<AudioZoneStatus> retrieveStatus() {
         try {
             int audioZoneID = getThingNumber();
             ObjectStatus objStatus = getOmnilinkBridgeHander().requestObjectStatus(Message.OBJ_TYPE_AUDIO_ZONE,
                     audioZoneID, audioZoneID, true);
-            handleAudioZoneStatus((AudioZoneStatus) objStatus.getStatuses()[0]);
+            return Optional.of((AudioZoneStatus) objStatus.getStatuses()[0]);
 
         } catch (OmniInvalidResponseException | OmniUnknownMessageTypeException | BridgeOfflineException e) {
             logger.debug("Unexpected exception refreshing unit:", e);
+            return Optional.empty();
         }
     }
-
 }

--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/ButtonHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/ButtonHandler.java
@@ -1,5 +1,7 @@
 package org.openhab.binding.omnilink.handler;
 
+import java.util.Optional;
+
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.Command;
@@ -12,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import com.digitaldan.jomnilinkII.OmniInvalidResponseException;
 import com.digitaldan.jomnilinkII.OmniUnknownMessageTypeException;
 import com.digitaldan.jomnilinkII.MessageTypes.CommandMessage;
+import com.digitaldan.jomnilinkII.MessageTypes.statuses.Status;
 
 /**
  *
@@ -43,5 +46,15 @@ public class ButtonHandler extends AbstractOmnilinkHandler {
         ChannelUID activateChannel = new ChannelUID(getThing().getUID(),
                 OmnilinkBindingConstants.TRIGGER_CHANNEL_BUTTON_ACTIVATED_EVENT);
         triggerChannel(activateChannel);
+    }
+
+    @Override
+    protected Optional retrieveStatus() {
+        return Optional.empty();
+    }
+
+    @Override
+    protected void updateChannels(Status t) {
+        // No links for buttons
     }
 }

--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/ConsoleHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/ConsoleHandler.java
@@ -1,5 +1,7 @@
 package org.openhab.binding.omnilink.handler;
 
+import java.util.Optional;
+
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -12,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import com.digitaldan.jomnilinkII.OmniInvalidResponseException;
 import com.digitaldan.jomnilinkII.OmniUnknownMessageTypeException;
 import com.digitaldan.jomnilinkII.MessageTypes.CommandMessage;
+import com.digitaldan.jomnilinkII.MessageTypes.statuses.Status;
 
 /**
  *
@@ -51,5 +54,15 @@ public class ConsoleHandler extends AbstractOmnilinkHandler {
             logger.debug("Could not send console command to omnilink", e);
         }
 
+    }
+
+    @Override
+    protected Optional retrieveStatus() {
+        return Optional.empty();
+    }
+
+    @Override
+    protected void updateChannels(Status t) {
+        // No Status.
     }
 }

--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/OmnilinkBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/OmnilinkBridgeHandler.java
@@ -260,8 +260,7 @@ public class OmnilinkBridgeHandler extends BaseBridgeHandler implements Notifica
                 Integer number = new Integer(stat.getNumber());
                 logger.debug("received status update for zone: {},status: {}", number, stat.getStatus());
                 Optional<Thing> theThing = getChildThing(OmnilinkBindingConstants.THING_TYPE_ZONE, stat.getNumber());
-                theThing.map(Thing::getHandler)
-                        .ifPresent(theHandler -> ((ZoneHandler) theHandler).handleZoneStatus(stat));
+                theThing.map(Thing::getHandler).ifPresent(theHandler -> ((ZoneHandler) theHandler).handleStatus(stat));
             } else if (status instanceof AreaStatus) {
                 AreaStatus areaStatus = (AreaStatus) status;
                 // TODO we should check if this is a lumina system and return that if so
@@ -274,8 +273,8 @@ public class OmnilinkBridgeHandler extends BaseBridgeHandler implements Notifica
                 ExtendedThermostatStatus thermostatStatus = (ExtendedThermostatStatus) status;
                 Optional<Thing> theThing = getChildThing(OmnilinkBindingConstants.THING_TYPE_THERMOSTAT,
                         status.getNumber());
-                theThing.map(Thing::getHandler).ifPresent(
-                        theHandler -> ((ThermostatHandler) theHandler).handleThermostatStatus(thermostatStatus));
+                theThing.map(Thing::getHandler)
+                        .ifPresent(theHandler -> ((ThermostatHandler) theHandler).handleStatus(thermostatStatus));
             } else if (status instanceof AudioZoneStatus) {
                 AudioZoneStatus audioZoneStatus = (AudioZoneStatus) status;
                 Optional<Thing> theThing = getChildThing(OmnilinkBindingConstants.THING_TYPE_AUDIO_ZONE,

--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/OmnilinkBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/handler/OmnilinkBridgeHandler.java
@@ -268,7 +268,7 @@ public class OmnilinkBridgeHandler extends BaseBridgeHandler implements Notifica
                         status.getNumber());
                 logger.debug("AreaStatus: Mode={}", areaStatus.getMode());
                 theThing.map(Thing::getHandler)
-                        .ifPresent(theHandler -> ((AreaHandler) theHandler).handleAreaEvent(areaStatus));
+                        .ifPresent(theHandler -> ((AreaHandler) theHandler).updateChannels(areaStatus));
             } else if (status instanceof ExtendedThermostatStatus) {
                 ExtendedThermostatStatus thermostatStatus = (ExtendedThermostatStatus) status;
                 Optional<Thing> theThing = getChildThing(OmnilinkBindingConstants.THING_TYPE_THERMOSTAT,
@@ -279,8 +279,8 @@ public class OmnilinkBridgeHandler extends BaseBridgeHandler implements Notifica
                 AudioZoneStatus audioZoneStatus = (AudioZoneStatus) status;
                 Optional<Thing> theThing = getChildThing(OmnilinkBindingConstants.THING_TYPE_AUDIO_ZONE,
                         status.getNumber());
-                theThing.map(Thing::getHandler).ifPresent(
-                        theHandler -> ((AudioZoneHandler) theHandler).handleAudioZoneStatus(audioZoneStatus));
+                theThing.map(Thing::getHandler)
+                        .ifPresent(theHandler -> ((AudioZoneHandler) theHandler).updateChannels(audioZoneStatus));
             } else {
                 logger.debug("Received Object Status Notification that was not processed: {}", objectStatus);
             }


### PR DESCRIPTION
This should not be merged in its present state. 
@craigham and @digitaldan can you take a look at this?  
This is my pass at closing #44 now that we have all immutable status objects in the core library.  

@digitaldan - I lifted most of your code up that you prototyped in the ZoneHandler into the AbstractOmniHandler because it is repeated across all handler objects.  

Handlers now need to implement a generified retrieveStatus and a generified updateChannels.  External callers should now call the generified handleStatus for all updates.  The super class now handles all the null (empty) checking, etc for status. 

If we like this approach, I will apply it to the rest of the handlers.