### PR TITLE
Report controller ID during  thermostat discovery

### DIFF
--- a/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/discovery/OmnilinkDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/discovery/OmnilinkDiscoveryService.java
@@ -241,7 +241,7 @@ public class OmnilinkDiscoveryService extends AbstractDiscoveryService {
             for (ThermostatProperties thermostatProperties : objectPropertyRequest) {
 
                 ThingUID thingUID = new ThingUID(OmnilinkBindingConstants.THING_TYPE_THERMOSTAT,
-                        Integer.toString(thermostatProperties.getNumber()));
+                        bridgeHandler.getThing().getUID(), Integer.toString(thermostatProperties.getNumber()));
 
                 Map<String, Object> properties = new HashMap<>();
                 properties.put(OmnilinkBindingConstants.THING_PROPERTIES_NUMBER, thermostatProperties.getNumber());


### PR DESCRIPTION
Added bridge UUID to thermostat ThingUID.

This fixes #123 
